### PR TITLE
ci: apply Zizmor recs, replace unmaintained actions, update Node

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,43 +8,43 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Tests
-    env:
-      RUSTFLAGS: "-D warnings -C debuginfo=1"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           toolchain: stable
           components: rustfmt, clippy
-
-      - name: Setup build cache
-        uses: Swatinem/rust-cache@v2
+          rustflags: "-D warnings -C debuginfo=1"
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features --workspace -- -D warnings
+        shell: bash
+        run: |
+          cargo clippy --all-targets --all-features --workspace -- -D warnings
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        uses: actions-rust-lang/rustfmt@559aa3035a47390ba96088dffa783b5d26da9326 # v1.1.1
 
       - name: Unit tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace
+        shell: bash
+        run: |
+          cargo test --workspace

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,57 +6,59 @@ on:
     # run this workflow every day at 1:42 AM UTC
     - cron: '42 1 * * *'
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: All tests
-    env:
-      RUSTFLAGS: "-D warnings -C debuginfo=1"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           toolchain: stable
           components: rustfmt, clippy
+          rustflags: "-D warnings -C debuginfo=1"
 
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '18'
-
-      - name: Setup build cache
-        uses: Swatinem/rust-cache@v2
+          node-version: 22
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features --workspace -- -D warnings
+        shell: bash
+        run: |
+          cargo clippy --all-targets --all-features --workspace -- -D warnings
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        uses: actions-rust-lang/rustfmt@559aa3035a47390ba96088dffa783b5d26da9326 # v1.1.1
 
       - name: Unit tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace
+        shell: bash
+        run: |
+          cargo test --workspace
 
       - name: Generate numbers
+        shell: bash
         run: |
           cd tests/resources/generated-numbers
           node numgen.js
 
       - name: Test on generated numbers
+        shell: bash
         run: |
           cargo test --tests generated_numbers -- --nocapture --include-ignored


### PR DESCRIPTION
* Apply Zizmor recommendations, including removing unnecessary permissions, setting concurrency limits, setting `persist-credentials: false` on `actions/checkout`, and pinning dependencies using commit hashes.
* Replace unmaintained and archived `actions-rs` dependencies with actively maintained `actions-rust-lang` for setting up Rust toolchain and checking code formatting. This automatically sets up the build cache so we no longer need to invoke `rust-cache` directly. Other uses of `actions-rs/cargo` are simply replaced with direct calls to cargo.
* Set `fail-fast: false` on matrix-strategy jobs.
* Update Node to version 22.